### PR TITLE
fix typo and add lazy.nvim install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is how to install nvim-github-codesearch using `packer`
 ### Configuration + Usage
 Here is how to setup this plugin:
 ```lua
-gh_seach = require("nvim-github-codesearch")
+local gh_search = require("nvim-github-codesearch")
 gh_search.setup({
   -- an optional table entry to explicitly configure the API key to use for Github API requests.
   -- alternatively, you can configure this parameter by export an environment variable named "GITHUB_AUTH_TOKEN"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Here is how to install nvim-github-codesearch using `packer`
   -- with out this parameter the plugin will miss the compilation step entirely
   use {'napisani/nvim-github-codesearch', run = 'make'}
 ```
+Install using `lazy.nvim`
+```lua
+  {'napisani/nvim-github-codesearch', build = 'make'}
+```
 
 ### Configuration + Usage
 Here is how to setup this plugin:


### PR DESCRIPTION
I fix a typo gh_seach to gh_search and added install script for lazy.nvim