### PR TITLE
Fix the build for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 !/.cargo/config
 /.git/
 *.so
+*.dylib

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	mkdir -p ./lib/
 	
 	# Remove old shared library
-	rm -f ./lua/libgithub_search.$(LIB_EXT)
+	rm -f ./lua/libgithub_search.so
 	
 	# Copy new shared library to target directory
 	# NOTE: Use .so even on Mac due to weird issue loading .dylib

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ build:
 	rm -f ./lua/libgithub_search.$(LIB_EXT)
 	
 	# Copy new shared library to target directory
-	cp ./target/release/libgithub_search.$(LIB_EXT) ./lua/libgithub_search.$(LIB_EXT)
+	# NOTE: Use .so even on Mac due to weird issue loading .dylib
+	# https://github.com/Joakker/lua-json5/issues/4
+	# https://github.com/neovim/neovim/issues/21749#issuecomment-1418427487
+	cp ./target/release/libgithub_search.$(LIB_EXT) ./lua/libgithub_search.so
 	
 	# If your Rust project has dependencies,
 	# you'll need to do this as well

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
 .PHONY: build
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LIB_EXT := dylib
+else
+	LIB_EXT := so
+endif
 build:
 	cargo build --release
 	mkdir -p ./lua/deps/
 	mkdir -p ./lib/
-	rm -f ./lua/libgithub_search.so
-	cp ./target/release/libgithub_search.so ./lua/libgithub_search.so
-	# if your Rust project has dependencies,
+	
+	# Remove old shared library
+	rm -f ./lua/libgithub_search.$(LIB_EXT)
+	
+	# Copy new shared library to target directory
+	cp ./target/release/libgithub_search.$(LIB_EXT) ./lua/libgithub_search.$(LIB_EXT)
+	
+	# If your Rust project has dependencies,
 	# you'll need to do this as well
 	cp ./target/release/deps/*.rlib ./lua/deps/


### PR DESCRIPTION
Fix build errors for mac

Note that i added this to make the build work based off the error message:
```
export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/opt/homebrew/Cellar/luajit/2.1.1703358377/lib/pkgconfig"
```

https://github.com/napisani/nvim-github-codesearch/issues/2#issuecomment-1989759849

It would be good if someone can make sure it still works on linux before merging

NOTE: Use .so even on Mac due to weird issue loading .dylib
https://github.com/Joakker/lua-json5/issues/4
https://github.com/neovim/neovim/issues/21749#issuecomment-1418427487

Tell me if there's a better way than renaming `.dylib` to `.so`